### PR TITLE
[docs] maintenance

### DIFF
--- a/docs/source/definition.rst
+++ b/docs/source/definition.rst
@@ -1,0 +1,5 @@
+===========
+Definitions
+===========
+
+.. automodule:: physlearn.supervised.utils._definition

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,6 +43,7 @@ Contents
    Base Boosting <baseboosting>
    Python API <python_api>
    Datasets API <datasets_api>
+   Definitions <definition>
    Developer Tools <developer_tools>
    License <license>
 

--- a/docs/source/learning_curve.rst
+++ b/docs/source/learning_curve.rst
@@ -3,5 +3,10 @@ Learning Curve API
 ==================
 
 .. automodule:: physlearn.supervised.model_selection.learning_curve
+    :exclude-members: _check_n_features, _check_target_index, _estimate_fold_size,
+        _fit, _get_param_names, _get_regressor, _modified_cross_validate,
+        _repr_html_, _repr_html_inner, _repr_mimebundle_, _validate_data,
+        check_regressor, cross_val_score, cross_validate, dump, fit, get_params,
+        get_pipeline, load, predict, regattr, score, set_params
 
 .. autofunction:: physlearn.plot_learning_curve

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -8,9 +8,11 @@ This is a quick start guide for scikit-physlearn.
 
 - :doc:`Installation guide </install>`
 
+- :doc:`Python API </python_api>`
+
 - :doc:`Base boosting </baseboosting>`
 
-- :doc:`Python API </python_api>`
+- :doc:`Regressor definitions <definition>`
 
 Python
 ------

--- a/docs/source/shap.rst
+++ b/docs/source/shap.rst
@@ -3,4 +3,4 @@ SHAP API
 ========
 
 .. automodule:: physlearn.supervised.interpretation.interpret_regressor
-   :members:
+   :exclude-members: _check_n_features

--- a/docs/source/whatisphyslearn.rst
+++ b/docs/source/whatisphyslearn.rst
@@ -26,7 +26,7 @@ it includes ``fit``, ``predict``, and ``score`` methods, as well as:
   Bayesian optimization.
 - Cross-validation methods such as ``cross_validate``, ``cross_val_score``,
   and ``nested_cross_validate``.
-- A base boosting method with inbuilt k-fold cross-validation.
+- A base boosting method with built-in model selection.
 
 ********
 Citation

--- a/physlearn/supervised/interpretation/interpret_regressor.py
+++ b/physlearn/supervised/interpretation/interpret_regressor.py
@@ -1,7 +1,8 @@
 """
-The :mod:`physlearn.supervised.interpretation.interpret_regressor` module provides
-SHAP utilities for regressor interpretability. It includes the 
-:class:`physlearn.ShapInterpret` class.
+The :mod:`physlearn.supervised.interpretation.interpret_regressor`
+module provides SHAP utilities for regressor interpretability.
+It includes the :class:`physlearn.ShapInterpret`
+class.
 """
 
 # Author: Alex Wozniakowski


### PR DESCRIPTION
The sklearn ``BaseEstimator`` attribute ``_check_n_features`` causes a warning due to unexpected indentation.